### PR TITLE
Document local CUDA env in .cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,13 +1,25 @@
+# Cargo configuration for hello-gpu
+#
+# Set the following environment variables to match your local CUDA and MSVC
+# installation. They may be defined here or exported in your shell.
+#
+# CUDA_PATH              - root of the CUDA Toolkit, e.g. C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.5
+# CUDA_TOOLKIT_ROOT_DIR  - usually the same as CUDA_PATH
+# CUDA_LIBRARY_PATH      - path to the 64-bit CUDA libs, typically ${CUDA_PATH}\\lib\\x64
+# CCBIN_PATH             - full path to cl.exe from the Visual Studio Build Tools
+#
+# Using placeholders keeps the file portable across machines.
+
+[env]
+CUDA_PATH = "${CUDA_PATH}"
+CUDA_TOOLKIT_ROOT_DIR = "${CUDA_PATH}"
+CUDA_LIBRARY_PATH = "${CUDA_PATH}\\lib\\x64"
+CCBIN_PATH = "${CCBIN_PATH}"
+
 [target.'cfg(windows)']
 rustflags = [
-    "-C", "link-arg=/LIBPATH:C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.5\\lib\\x64",
+    "-C", "link-arg=/LIBPATH:${CUDA_LIBRARY_PATH}",
     "-C", "link-arg=cudart.lib",
     "-C", "link-arg=cuda.lib",
     "-C", "link-arg=cudadevrt.lib",
 ]
-
-[env]
-CUDA_PATH = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.5"
-CUDA_TOOLKIT_ROOT_DIR = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.5"
-CUDA_LIBRARY_PATH = "C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v12.5\\lib\\x64"
-CCBIN_PATH = "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.41.34120\\bin\\Hostx64\\x64\\cl.exe"


### PR DESCRIPTION
## Summary
- replace Windows-specific paths with documentation and placeholders
- keep `[env]` section with variables but not machine-specific values

## Testing
- `cargo build` *(fails: CUDA SDK cannot be found)*

------
https://chatgpt.com/codex/tasks/task_e_684aef3470248328adbc9d7f8f7ce3fa